### PR TITLE
Faster diacritics removal: 5x to 18x.

### DIFF
--- a/benchmarks/DiacriticsBench.elm
+++ b/benchmarks/DiacriticsBench.elm
@@ -49,6 +49,8 @@ suite =
         ]
 
 
+{-| This is the earlier algorithm, for comparison.
+-}
 removeDiacritics : String -> String
 removeDiacritics str =
     let

--- a/benchmarks/DiacriticsBench.elm
+++ b/benchmarks/DiacriticsBench.elm
@@ -38,8 +38,8 @@ suite =
 
         bench description str =
             Benchmark.compare description
-                "original"
-                (\_ -> removeDiacritics str)
+                "old"
+                (\_ -> oldRemoveDiacritics str)
                 "new"
                 (\_ -> Normalize.removeDiacritics str)
     in
@@ -49,10 +49,8 @@ suite =
         ]
 
 
-{-| This is the earlier algorithm, for comparison.
--}
-removeDiacritics : String -> String
-removeDiacritics str =
+oldRemoveDiacritics : String -> String
+oldRemoveDiacritics str =
     let
         replace c result =
             case Dict.get c Diacritics.lookupTable of

--- a/benchmarks/DiacriticsBench.elm
+++ b/benchmarks/DiacriticsBench.elm
@@ -1,0 +1,59 @@
+module Main exposing (main)
+
+{-| To run the benchmarks, first compile them with
+
+    elm make benchmarks / DiacriticsBench.elm --optimize
+
+from the root directory of the project. Then open the generated
+index.html file in a browser.
+
+-}
+
+import Array exposing (Array)
+import Benchmark exposing (..)
+import Benchmark.Runner exposing (BenchmarkProgram, program)
+import Dict exposing (Dict)
+import Set exposing (Set)
+import String.Normalize as Normalize
+import String.Normalize.Diacritics as Diacritics
+
+
+main : BenchmarkProgram
+main =
+    program suite
+
+
+suite : Benchmark
+suite =
+    let
+        aboveMinString =
+            "£££££££££££££££££££££££££££££££££££££"
+
+        belowMinString =
+            "asdfereqerqerpqoiweruqwerqwerpqoweAAA"
+
+        bench description str =
+            Benchmark.compare description
+                "original"
+                (\_ -> removeDiacritics str)
+                "new"
+                (\_ -> Normalize.removeDiacritics str)
+    in
+    Benchmark.describe "remove diacritics"
+        [ bench "below lowest diacritic code" belowMinString
+        , bench "above lowest diacritic code" aboveMinString
+        ]
+
+
+removeDiacritics : String -> String
+removeDiacritics str =
+    let
+        replace c result =
+            case Dict.get c Diacritics.lookupTable of
+                Just candidate ->
+                    result ++ candidate
+
+                Nothing ->
+                    result ++ String.fromChar c
+    in
+    String.foldl replace "" str

--- a/benchmarks/DiacriticsBench.elm
+++ b/benchmarks/DiacriticsBench.elm
@@ -26,9 +26,13 @@ main =
 suite : Benchmark
 suite =
     let
+        -- These characters have a higher Unicode code point than the
+        -- lowest diacritic code point.
         aboveMinString =
             "£££££££££££££££££££££££££££££££££££££"
 
+        -- These characters have lower Unicode code points than the
+        -- lowest diacritic code point.
         belowMinString =
             "asdfereqerqerpqoiweruqwerqwerpqoweAAA"
 

--- a/elm.json
+++ b/elm.json
@@ -9,7 +9,8 @@
     ],
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
-        "elm/core": "1.0.0 <= v < 2.0.0"
+        "elm/core": "1.0.0 <= v < 2.0.0",
+        "elm-explorations/benchmark": "1.0.2 <= v < 2.0.0"
     },
     "test-dependencies": {
         "elm-explorations/test": "1.0.0 <= v < 2.0.0"

--- a/src/String/Normalize.elm
+++ b/src/String/Normalize.elm
@@ -21,6 +21,7 @@ import Char
 import Dict
 import Set exposing (Set)
 import String.Normalize.Diacritics as Diacritics
+import Array
 
 
 {-| `removeDiacritics` removes diactritics, it will expand
@@ -40,12 +41,20 @@ removeDiacritics : String -> String
 removeDiacritics str =
     let
         replace c result =
-            case Dict.get c Diacritics.lookupTable of
-                Just candidate ->
-                    result ++ candidate
+            if Char.toCode c < Diacritics.minCode then
+                result ++ String.fromChar c
 
-                Nothing ->
-                    result ++ String.fromChar c
+            else
+                case
+                    Array.get
+                        (Char.toCode c)
+                        Diacritics.lookupArray
+                of
+                    Just candidate ->
+                        result ++ candidate
+
+                    Nothing ->
+                        result ++ String.fromChar c
     in
     String.foldl replace "" str
 

--- a/src/String/Normalize/Diacritics.elm
+++ b/src/String/Normalize/Diacritics.elm
@@ -9,8 +9,8 @@ lookupTable =
     Dict.fromList lookupList
 
 
-{-| The array indices are Unicode code points. The array values
-contents are the strings to replace them with.
+{-| The array indices are Unicode code points. The array contents are
+the strings to replace them with.
 -}
 lookupArray : Array String
 lookupArray =

--- a/src/String/Normalize/Diacritics.elm
+++ b/src/String/Normalize/Diacritics.elm
@@ -9,6 +9,9 @@ lookupTable =
     Dict.fromList lookupList
 
 
+{-| The array indices are Unicode code points. The array values
+contents are the strings to replace them with.
+-}
 lookupArray : Array String
 lookupArray =
     List.range 0 maxCode
@@ -22,6 +25,8 @@ lookupArray =
     |> Array.fromList
 
 
+{-| The highest Unicode code point of all the diacritics.
+-}
 maxCode : Int
 maxCode =
     lookupList
@@ -39,6 +44,8 @@ maxUnicode =
     0x10FFFF
 
 
+{-| The lowest Unicode code point of all the diacritics.
+-}
 minCode : Int
 minCode =
     lookupList

--- a/src/String/Normalize/Diacritics.elm
+++ b/src/String/Normalize/Diacritics.elm
@@ -1,7 +1,7 @@
-module String.Normalize.Diacritics exposing (lookupTable, lookupArray, minCode)
+module String.Normalize.Diacritics exposing (lookupArray, lookupTable, minCode)
 
-import Dict exposing (Dict, insert)
 import Array exposing (Array)
+import Dict exposing (Dict, insert)
 
 
 lookupTable : Dict Char String
@@ -15,14 +15,16 @@ contents are the strings to replace them with.
 lookupArray : Array String
 lookupArray =
     List.range 0 maxCode
-    |> List.map (\i ->
-        case Dict.get (Char.fromCode i) lookupTable of
-            Nothing ->
-                String.fromChar (Char.fromCode i)
+        |> List.map
+            (\i ->
+                case Dict.get (Char.fromCode i) lookupTable of
+                    Nothing ->
+                        String.fromChar (Char.fromCode i)
 
-            Just str ->
-                str)
-    |> Array.fromList
+                    Just str ->
+                        str
+            )
+        |> Array.fromList
 
 
 {-| The highest Unicode code point of all the diacritics.
@@ -30,18 +32,18 @@ lookupArray =
 maxCode : Int
 maxCode =
     lookupList
-    |> List.map Tuple.first
-    |> List.map Char.toCode
-    |> List.maximum
-    |> Maybe.withDefault maxUnicode
+        |> List.map Tuple.first
+        |> List.map Char.toCode
+        |> List.maximum
+        |> Maybe.withDefault maxUnicode
 
 
 {-| The highest Unicode code point, see
-https://stackoverflow.com/a/27416004/6629874
+<https://stackoverflow.com/a/27416004/6629874>
 -}
 maxUnicode : Int
 maxUnicode =
-    0x10FFFF
+    0x0010FFFF
 
 
 {-| The lowest Unicode code point of all the diacritics.
@@ -49,10 +51,10 @@ maxUnicode =
 minCode : Int
 minCode =
     lookupList
-    |> List.map Tuple.first
-    |> List.map Char.toCode
-    |> List.minimum
-    |> Maybe.withDefault 0
+        |> List.map Tuple.first
+        |> List.map Char.toCode
+        |> List.minimum
+        |> Maybe.withDefault 0
 
 
 lookupList : List ( Char, String )

--- a/src/String/Normalize/Diacritics.elm
+++ b/src/String/Normalize/Diacritics.elm
@@ -1,11 +1,51 @@
-module String.Normalize.Diacritics exposing (lookupTable)
+module String.Normalize.Diacritics exposing (lookupTable, lookupArray, minCode)
 
 import Dict exposing (Dict, insert)
+import Array exposing (Array)
 
 
 lookupTable : Dict Char String
 lookupTable =
     Dict.fromList lookupList
+
+
+lookupArray : Array String
+lookupArray =
+    List.range 0 maxCode
+    |> List.map (\i ->
+        case Dict.get (Char.fromCode i) lookupTable of
+            Nothing ->
+                String.fromChar (Char.fromCode i)
+
+            Just str ->
+                str)
+    |> Array.fromList
+
+
+maxCode : Int
+maxCode =
+    lookupList
+    |> List.map Tuple.first
+    |> List.map Char.toCode
+    |> List.maximum
+    |> Maybe.withDefault maxUnicode
+
+
+{-| The highest Unicode code point, see
+https://stackoverflow.com/a/27416004/6629874
+-}
+maxUnicode : Int
+maxUnicode =
+    0x10FFFF
+
+
+minCode : Int
+minCode =
+    lookupList
+    |> List.map Tuple.first
+    |> List.map Char.toCode
+    |> List.minimum
+    |> Maybe.withDefault 0
 
 
 lookupList : List ( Char, String )

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -61,7 +61,31 @@ removeDiacriticsTests =
                         removeDiacritics firstPass
                 in
                 Expect.equal firstPass secondPass
+        , fuzz
+            withDiacritics
+            "no regression with optimized version"
+          <|
+            \randomString ->
+                let
+                    old = oldRemoveDiacritics randomString
+                    new = removeDiacritics randomString
+                in
+                Expect.equal old new
         ]
+
+
+oldRemoveDiacritics : String -> String
+oldRemoveDiacritics str =
+    let
+        replace c result =
+            case Dict.get c lookupTable of
+                Just candidate ->
+                    result ++ candidate
+
+                Nothing ->
+                    result ++ String.fromChar c
+    in
+    String.foldl replace "" str
 
 
 unicode : Fuzz.Fuzzer String


### PR DESCRIPTION
Faster `String.Normalize.removeDiacritics`. Benchmarks in Chrome:
![Screenshot from 2022-03-20 16-51-44](https://user-images.githubusercontent.com/14153190/159173390-5f005003-ad73-48d0-89e1-4d91631af296.png)
