### PR TITLE
Remove the benchmarks dependency

### DIFF
--- a/benchmarks/DiacriticsBench.elm
+++ b/benchmarks/DiacriticsBench.elm
@@ -1,11 +1,10 @@
-module Main exposing (main)
+module DiacriticsBench exposing (main)
 
 {-| To run the benchmarks, first compile them with
 
-    elm make benchmarks / DiacriticsBench.elm --optimize
+    elm make DiacriticsBench.elm --optimize
 
-from the root directory of the project. Then open the generated
-index.html file in a browser.
+from this folder. Then open the generated index.html file in a browser.
 
 -}
 

--- a/benchmarks/elm.json
+++ b/benchmarks/elm.json
@@ -1,0 +1,30 @@
+{
+    "type": "application",
+    "source-directories": [
+        ".",
+        "../src"
+    ],
+    "elm-version": "0.19.1",
+    "dependencies": {
+        "direct": {
+            "elm/browser": "1.0.2",
+            "elm/core": "1.0.5",
+            "elm/html": "1.0.0",
+            "elm-explorations/benchmark": "1.0.2"
+        },
+        "indirect": {
+            "BrianHicks/elm-trend": "2.1.3",
+            "elm/json": "1.1.3",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0",
+            "elm/url": "1.0.0",
+            "elm/virtual-dom": "1.0.3",
+            "mdgriffith/style-elements": "5.0.2",
+            "robinheghan/murmur3": "1.0.0"
+        }
+    },
+    "test-dependencies": {
+        "direct": {},
+        "indirect": {}
+    }
+}

--- a/elm.json
+++ b/elm.json
@@ -9,8 +9,7 @@
     ],
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
-        "elm/core": "1.0.0 <= v < 2.0.0",
-        "elm-explorations/benchmark": "1.0.2 <= v < 2.0.0"
+        "elm/core": "1.0.0 <= v < 2.0.0"
     },
     "test-dependencies": {
         "elm-explorations/test": "1.0.0 <= v < 2.0.0"


### PR DESCRIPTION
Currently this package depends on `benchmark` package unnecessarily. This dependency can live in the `benchmarks/` directory, unrelated to the package itself.

See what happens when I try to use this package:

<img width="650" alt="185680127-53677f72-0f6e-4987-bfc1-5f9a94eb874f" src="https://user-images.githubusercontent.com/149425/185680884-171d4c5f-4fab-4bdb-8e6f-4a79d6fc5c14.png">
